### PR TITLE
Domain mapping

### DIFF
--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -1,21 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.orm import Session
-from app.core.database import get_db
+from app.core.database import (get_db, 
+    generateStudentInformationReport, 
+    generateGradeReport, 
+    generateExamReport
+)
 from app.core.security import (
     get_current_active_user
 )
 from app.models import LoginInfo as User
 from app.models import (
-    Student,
-    GraduationStatus,
-    Exam,
-    ExamResults,
-    GradeClassification,
-    StudentGrade,
-    ClassOffering
+    Student
 )
-from app.schemas.reportschema import StudentReport, ExamReport, GradeReport, StudentCompleteReport
+from app.schemas.reportschema import StudentCompleteReport
 
 import pandas as pd
 import io
@@ -25,100 +23,6 @@ from datetime import datetime
 
 router = APIRouter()
 
-def generateStudentInformationReport(student_id, db):
-    data = db.query(
-        Student.studentid,
-        Student.lastname,
-        Student.firstname,
-        Student.cumgpa,
-        Student.bcpmgpa,
-        Student.mmicalc,
-        GraduationStatus.rosteryear,
-        GraduationStatus.graduationyear,
-        GraduationStatus.graduated,
-        GraduationStatus.graduationlength,
-        GraduationStatus.status
-    ).join(
-        GraduationStatus, Student.studentid == GraduationStatus.studentid
-    ).filter(
-        Student.studentid == student_id
-    ).first()
-    
-    '''
-    Pydantic handeling Float(NaN) to None conversion will not need to handle
-    multiple rows as a student will only have a singular student report
-    '''
-    studentinformation = StudentReport(
-        StudentID = data.studentid,
-        LastName = data.lastname,
-        FirstName = data.firstname,
-        CumGPA = data.bcpmgpa,
-        MMICalc = data.mmicalc,
-        RosterYear = data.rosteryear,
-        GraduationYear = data.graduationyear,
-        Graduated = data.graduated,
-        GraduationLength = data.graduationlength,
-        Status = data.status
-    )
-    
-    return studentinformation
-
-def generateExamReport(student_id, db):
-    data = db.query(
-        Exam.examname,
-        ExamResults.score,
-        Exam.passscore,
-        ExamResults.passorfail
-    ).join(
-        Exam, ExamResults.examid == Exam.examid
-    ).filter(
-        ExamResults.studentid == student_id
-    ).all()
-    
-    exams = []
-    #Converting to a dictionary as there can be multiple records of exams
-    for row in data:
-        exam_dict = {
-            "ExamName": row[0],
-            "Score": row[1],
-            "PassScore": row[2],
-            "PassOrFail": row[3]
-        }
-        pydanticData = ExamReport(**exam_dict)
-        exams.append(pydanticData)
-        
-    return exams
-
-def generateGradeReport(student_id, db):
-    data = db.query(
-        GradeClassification.classificationname,
-        StudentGrade.pointsearned,
-        StudentGrade.pointsavailable,
-        ClassOffering.classid,
-        ClassOffering.datetaught
-    ).join(
-        GradeClassification, StudentGrade.gradeclassificationid == GradeClassification.gradeclassificationid
-    ).join(
-        ClassOffering, GradeClassification.classofferingid == ClassOffering.classofferingid
-    ).filter(
-        StudentGrade.studentid == student_id
-    ).all()
-    
-    grades = []
-    #Converting to dictionary as there can be multiple records of grades
-    for row in data:
-        grade_dict = {
-            "ClassificationName": row[0],
-            "PointsEarned": row[1],
-            "PointsAvailable": row[2],
-            "ClassID": row[3],
-            "DateTaught": row[4]
-        }
-        pydanticData = GradeReport(**grade_dict)
-        grades.append(pydanticData)
-        
-    return grades
-    
 #Generates a student report based on a student's information, total exams, and grades
 @router.get("/report", response_model=StudentCompleteReport)
 async def generate_report(
@@ -168,3 +72,4 @@ async def generate_report(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while processing your request"
         )
+        

--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -72,7 +72,9 @@ async def generate_report(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while processing your request"
         )
-        
+
+# Generates a domain report about a student, does not contain exams or student informaiton 
+# Only contains grades mapped to a specific domain    
 @router.get("/domainreport", response_model=DomainGrouping)
 async def generate_domain_report(
     current_user: User = Depends(get_current_active_user),

--- a/backend/app/api/v1/endpoints/student.py
+++ b/backend/app/api/v1/endpoints/student.py
@@ -3,8 +3,8 @@ from sqlalchemy.orm import Session
 import json
 import numpy as np
 from typing import Dict, List, Tuple
-from ....schemas.pydantic_base_models.user_schemas import StudentSchema
-from ....core.database import get_db, link_logininfo
+from ....schemas.reportschema import StudentReport
+from ....core.database import get_db, link_logininfo, generateStudentInformationReport
 from app.models import Student, LoginInfo as User
 from app.core.security import (
     get_current_active_user
@@ -51,4 +51,42 @@ async def update_login(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while processing your request"
         )
+
+@router.get("/info", response_model=StudentReport)
+async def generate_report(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    try:
+        print(current_user.username)
+        if current_user.issuperuser:
+            raise HTTPException(
+                status_code=403,
+                detail="Admins accounts can not access student reports route"
+            )
+
+        studentid = db.query(Student.studentid).filter(Student.logininfoid == current_user.logininfoid).scalar()
+        if not studentid:
+            raise HTTPException(
+                status_code=404,
+                detail="Login Info is not Attached to a Student"
+            )
+        
+        studentinfo = generateStudentInformationReport(studentid, db)
+        if not studentinfo:
+            raise HTTPException(
+                status_code=404,
+                detail="No Student Info Found"
+            )
+        
+        return studentinfo
     
+    except HTTPException:
+        raise
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )

--- a/backend/app/api/v1/endpoints/student.py
+++ b/backend/app/api/v1/endpoints/student.py
@@ -58,7 +58,6 @@ async def generate_report(
     db: Session = Depends(get_db)
 ):
     try:
-        print(current_user.username)
         if current_user.issuperuser:
             raise HTTPException(
                 status_code=403,

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -109,7 +109,8 @@ def link_logininfo(studentid, logininfoid):
         db.commit()
         
     db.close()
-    
+
+#Pulls All the Information Relevant to Student 
 def generateStudentInformationReport(student_id, db):
     data = db.query(
         Student.studentid,
@@ -148,6 +149,7 @@ def generateStudentInformationReport(student_id, db):
     
     return studentinformation  
 
+#Pulls All Exams related to a specific student id
 def generateExamReport(student_id, db):
     data = db.query(
         Exam.examname,
@@ -174,6 +176,7 @@ def generateExamReport(student_id, db):
         
     return exams
 
+#Pull all grades, from all blocks (classes) that is related to a student
 def generateGradeReport(student_id, db):
     data = db.query(
         GradeClassification.classificationname,
@@ -204,6 +207,7 @@ def generateGradeReport(student_id, db):
         
     return grades
 
+#Special Case: Pulls all grades of a student with the NBME classificaiton attached.
 def generateDomainReport(student_id, db, domain_id: Optional[int] = None):
     query = db.query(
         Domain.domainname,

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4,6 +4,16 @@ from app.models import Student, LoginInfo
 from .config import settings
 from .base import Base
 import math
+from app.models import (
+    Student,
+    GraduationStatus,
+    Exam,
+    ExamResults,
+    GradeClassification,
+    StudentGrade,
+    ClassOffering
+)
+from app.schemas.reportschema import StudentReport, ExamReport, GradeReport, StudentCompleteReport
 
 engine = create_engine(settings.sync_database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -97,4 +107,96 @@ def link_logininfo(studentid, logininfoid):
         
     db.close()
     
+def generateStudentInformationReport(student_id, db):
+    data = db.query(
+        Student.studentid,
+        Student.lastname,
+        Student.firstname,
+        Student.cumgpa,
+        Student.bcpmgpa,
+        Student.mmicalc,
+        GraduationStatus.rosteryear,
+        GraduationStatus.graduationyear,
+        GraduationStatus.graduated,
+        GraduationStatus.graduationlength,
+        GraduationStatus.status
+    ).join(
+        GraduationStatus, Student.studentid == GraduationStatus.studentid
+    ).filter(
+        Student.studentid == student_id
+    ).first()
     
+    '''
+    Pydantic handeling Float(NaN) to None conversion will not need to handle
+    multiple rows as a student will only have a singular student report
+    '''
+    studentinformation = StudentReport(
+        StudentID = data.studentid,
+        LastName = data.lastname,
+        FirstName = data.firstname,
+        CumGPA = data.bcpmgpa,
+        MMICalc = data.mmicalc,
+        RosterYear = data.rosteryear,
+        GraduationYear = data.graduationyear,
+        Graduated = data.graduated,
+        GraduationLength = data.graduationlength,
+        Status = data.status
+    )
+    
+    return studentinformation  
+
+def generateExamReport(student_id, db):
+    data = db.query(
+        Exam.examname,
+        ExamResults.score,
+        Exam.passscore,
+        ExamResults.passorfail
+    ).join(
+        Exam, ExamResults.examid == Exam.examid
+    ).filter(
+        ExamResults.studentid == student_id
+    ).all()
+    
+    exams = []
+    #Converting to a dictionary as there can be multiple records of exams
+    for row in data:
+        exam_dict = {
+            "ExamName": row[0],
+            "Score": row[1],
+            "PassScore": row[2],
+            "PassOrFail": row[3]
+        }
+        pydanticData = ExamReport(**exam_dict)
+        exams.append(pydanticData)
+        
+    return exams
+
+def generateGradeReport(student_id, db):
+    data = db.query(
+        GradeClassification.classificationname,
+        StudentGrade.pointsearned,
+        StudentGrade.pointsavailable,
+        ClassOffering.classid,
+        ClassOffering.datetaught
+    ).join(
+        GradeClassification, StudentGrade.gradeclassificationid == GradeClassification.gradeclassificationid
+    ).join(
+        ClassOffering, GradeClassification.classofferingid == ClassOffering.classofferingid
+    ).filter(
+        StudentGrade.studentid == student_id
+    ).all()
+    
+    grades = []
+    #Converting to dictionary as there can be multiple records of grades
+    for row in data:
+        grade_dict = {
+            "ClassificationName": row[0],
+            "PointsEarned": row[1],
+            "PointsAvailable": row[2],
+            "ClassID": row[3],
+            "DateTaught": row[4]
+        }
+        pydanticData = GradeReport(**grade_dict)
+        grades.append(pydanticData)
+        
+    return grades

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,7 +16,9 @@ from .exam_models import (
 
 from .class_models import (
     Class,
-    ClassOffering
+    ClassOffering,
+    Domain,
+    ClassDomain
 )
 
 from .misc_models import (

--- a/backend/app/models/class_models.py
+++ b/backend/app/models/class_models.py
@@ -11,6 +11,7 @@ class Class(Base):
     block = Column('Block', Integer)
     
     offering = relationship('ClassOffering', back_populates='classInfo')
+    domainIntersection = relationship('ClassDomain', back_populates='classInfo')
 
 class ClassOffering(Base):
     __tablename__ = 'classoffering'
@@ -25,3 +26,22 @@ class ClassOffering(Base):
     classInfo = relationship('Class', back_populates='offering')
     gradeClassification = relationship('GradeClassification', back_populates='offering')
     enrollmentRecord = relationship('EnrollmentRecord', back_populates='offering')
+    
+class Domain(Base):
+    __tablename__ = 'domain'
+    
+    domainid = Column('domainid', Integer, Identity(start=1, increment=1), primary_key=True)
+    domainname = Column('domainname', String(255), nullable=False)
+    weight = Column('weight', Integer)
+    
+    domainIntersection = relationship('ClassDomain', back_populates='domainInfo')
+    
+class ClassDomain(Base):
+    __tablename__ = 'classdomain'
+    
+    classdomainid = Column('classdomainid', Integer, Identity(start=1, increment=1), primary_key=True)
+    classid = Column('classid', Integer, ForeignKey('class.ClassID'))
+    domainid = Column('domaindid', Integer, ForeignKey('domain.domainid'))
+    
+    classInfo = relationship('Class', back_populates='domainIntersection')
+    domainInfo = relationship('Domain', back_populates='domainIntersection')

--- a/backend/app/schemas/reportschema.py
+++ b/backend/app/schemas/reportschema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 #optional statements are present as dataset is incomplete or students are in progress
 class StudentReport(BaseModel):
@@ -43,3 +43,6 @@ class DomainReport(BaseModel):
     PointsAvailable: float
     ClassID: int
     DateTaught: int
+    
+class DomainGrouping(BaseModel):
+    Domains: Dict[str, List[DomainReport]]

--- a/backend/app/schemas/reportschema.py
+++ b/backend/app/schemas/reportschema.py
@@ -35,3 +35,11 @@ class StudentCompleteReport(BaseModel):
     StudentInfo: StudentReport
     Exams: List[ExamReport] = []
     Grades: List[GradeReport] = []
+    
+class DomainReport(BaseModel):
+    DomainName: str
+    ClassificationName: str
+    PointsEarned: float
+    PointsAvailable: float
+    ClassID: int
+    DateTaught: int

--- a/backend/app/scripts/data/ClassDomainMap.csv
+++ b/backend/app/scripts/data/ClassDomainMap.csv
@@ -1,0 +1,35 @@
+classid,Block Name,domainid
+631,Foundations and Principles of Medical Science I,1
+631,Foundations and Principles of Medical Science I,10
+631,Foundations and Principles of Medical Science I,11
+632,"Cardiovascular, Respiratory and Renal Systems I",5
+632,"Cardiovascular, Respiratory and Renal Systems I",6
+632,"Cardiovascular, Respiratory and Renal Systems I",10
+632,"Cardiovascular, Respiratory and Renal Systems I",11
+633,"Gastrointestinal, Endocrine and Reproductive Systems I",7
+633,"Gastrointestinal, Endocrine and Reproductive Systems I",8
+633,"Gastrointestinal, Endocrine and Reproductive Systems I",10
+633,"Gastrointestinal, Endocrine and Reproductive Systems I",11
+634,Musculoskeletal and Integumentary Systems,4
+634,Musculoskeletal and Integumentary Systems,10
+634,Musculoskeletal and Integumentary Systems,11
+635,Nervous System and Human Behavior I,3
+635,Nervous System and Human Behavior I,10
+635,Nervous System and Human Behavior I,11
+636,Foundations and Principles of Medical Science II,2
+636,Foundations and Principles of Medical Science II,10
+636,Foundations and Principles of Medical Science II,11
+637,Whole Body,9
+637,Whole Body,10
+637,Whole Body,11
+639,"Cardiovascular, Respiratory and Renal Systems II",5
+639,"Cardiovascular, Respiratory and Renal Systems II",6
+639,"Cardiovascular, Respiratory and Renal Systems II",10
+639,"Cardiovascular, Respiratory and Renal Systems II",11
+640,"Gastrointestinal, Endocrine and Reproductive Systems II",7
+640,"Gastrointestinal, Endocrine and Reproductive Systems II",8
+640,"Gastrointestinal, Endocrine and Reproductive Systems II",10
+640,"Gastrointestinal, Endocrine and Reproductive Systems II",11
+638,Nervous System and Human Behavior II,3
+638,Nervous System and Human Behavior II,10
+638,Nervous System and Human Behavior II,11

--- a/backend/app/scripts/id_ingest.py
+++ b/backend/app/scripts/id_ingest.py
@@ -66,9 +66,6 @@ if __name__ == "__main__":
     df_graduationstatus['Grad.yrs'] = df_graduationstatus['Grad.yrs'].apply(convertGradYear).replace({float('nan'): None})
     df_graduationstatus['Grad.Year'] = df_graduationstatus['Grad.Year'].replace(['Active', 'Dropped'], None)
     df_graduationstatus['Graduated'] = df_graduationstatus['Graduated'].fillna(0).astype(bool)
-    
-    #print(df_graduationstatus.dtypes)
-    #print(df_graduationstatus)
 
     #Adding Base Exam Name Data
     base_exam_data = {
@@ -79,15 +76,11 @@ if __name__ == "__main__":
     }
     
     df_exam_data = pd.DataFrame(base_exam_data)
-    #print(df_exam_data)
     
     #Adding Student Exam Data
     df_student_exam = df_unrdata[[
        'Random Number ID',  'MCATcalc', 'CBSE1 score', 'CBSE2 score', 'USMLE_Step1score', 'USMLE_STEP2score'
-    ]]
-    
-    #print(df_student_exam)
-    
+    ]] 
     
     #Adding Student Data
     try:
@@ -344,7 +337,6 @@ if __name__ == "__main__":
     finally:
         db.close()  
     
-    #print(df_student)
     
     
     

--- a/backend/app/tests/test_student.py
+++ b/backend/app/tests/test_student.py
@@ -1,0 +1,124 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from unittest.mock import patch, MagicMock
+
+from app.main import app
+from app.models import LoginInfo as User
+from app.core.database import get_db
+from app.schemas.reportschema import StudentReport, ExamReport, GradeReport, DomainReport, StudentCompleteReport
+from app.core.security import (
+    get_current_active_user
+)
+
+#Fixtures to set-up enviroment for testing
+@pytest.fixture
+def test_admin(mock_admin, mock_db):
+    app.dependency_overrides[get_current_active_user] = lambda: mock_admin
+    app.dependency_overrides[get_db] = lambda: mock_db
+    
+    client = TestClient(app)
+    
+    yield client
+
+    app.dependency_overrides = {}
+
+@pytest.fixture
+def test_student(mock_student, mock_db):
+    
+    app.dependency_overrides[get_current_active_user] = lambda: mock_student
+    app.dependency_overrides[get_db] = lambda: mock_db
+    
+    client = TestClient(app)
+    
+    yield client
+
+    app.dependency_overrides = {}
+
+@pytest.fixture
+def mock_db():
+    mock = MagicMock(spec=Session)
+    return mock
+
+@pytest.fixture
+def mock_student():
+    user = MagicMock(spec=User)
+    user.username = "amognus"
+    user.logininfoid = 1
+    user.issuperuser = False
+    user.isactive = True
+    return user
+
+@pytest.fixture
+def mock_admin():
+    user = MagicMock(spec=User)
+    user.username = "superamongus"
+    user.logininfoid = 2
+    user.issuperuser = True
+    user.isactive = True
+    return user
+
+@pytest.fixture
+def mock_studentdata():
+    return StudentReport(
+        StudentID = 1,
+        LastName = "Mama",
+        FirstName = "Joe",
+        CumGPA = 3.5,
+        MMICalc = 85.5,
+        RosterYear = 2022,
+        GraduationYear = 2026,
+        Graduated = False,
+        GraduationLength = 4,
+        Status = "Active"
+    ) 
+
+class TestStudent:
+    
+    def test_admin_access(self, test_admin):
+        
+        response = test_admin.get("/api/v1/student/info")
+        
+        #Checking that a 403 error is sent as Admins can not access the student route API 
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Admins accounts can not access student reports route"
+        
+    def test_logininfo_not_attached_student(self, test_student, mock_db):
+        
+        query_mock = MagicMock()
+        filter_mock = MagicMock()
+        
+        filter_mock.scalar.return_value = None
+        mock_db.query.return_value = query_mock
+        query_mock.filter.return_value = filter_mock
+
+        response = test_student.get("/api/v1/student/info")
+        
+        #Checking that correct 404 error and details are being sent
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Login Info is not Attached to a Student"
+        
+    def test_student_information(self, test_student, mock_studentdata, mock_db):
+        
+        query_mock = MagicMock()
+        filter_mock = MagicMock()
+        
+        filter_mock.scalar.return_value = 1
+        mock_db.query.return_value = query_mock
+        query_mock.filter.return_value = filter_mock
+        
+        with patch("app.api.v1.endpoints.student.generateStudentInformationReport", return_value=mock_studentdata):
+                
+            response = test_student.get("/api/v1/student/info")
+        
+        #Checking for a 200 OK response from the API Call
+        assert response.status_code == 200
+        
+        #Just testing 3 of the results no need to check the entire .json request if three matches all good
+        assert response.json()["StudentID"] == mock_studentdata.StudentID
+        assert response.json()["LastName"] == mock_studentdata.LastName
+        assert response.json()["FirstName"] == mock_studentdata.FirstName
+        
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Domain Report Route Done
New API Route has been created for Mapping out the front-end using the NBME classification mapping provided by Bailey 
Had to create multiple new tables, and had to think out how to map the data efficiently so front-end hooking wouldn't be too difficult 

Attached is the image of how that mapping looks like also due to the fact the block system does not easily line up 1 to 1 with NBME classifications (i.e some blocks overlap with multiple NBME domains)
![image](https://github.com/user-attachments/assets/74c3e354-ef3d-4486-bddb-7d664108990a)

A new intersection table called classdomain was created handling the multiple instances of a class overlapping with another domain. For most intent and purposes you really won't be interacting with this table that much as the domain route will cover everything you would need but it's good to know that it exists.
With that multiple mapping in mind Some Grades Will Overlap Into Other Domains an attached images shows this by showing the same grades appearing in multiple domains. 
![image](https://github.com/user-attachments/assets/5660cc91-be48-45f5-bd7c-de1e931f2ae8)


For the actual API call  "http://localhost:8000/api/v1/domainreport" will handle both singular and all domain reports 
There is an optional field allowing to specify a specific domain id (refer to the image to see the mapping) if there is no domain_id added it will just query all the domain grades in the database and give it as one giant json package
If a field is added it will only return one domain. Both of these API call json files for student 328 is shown. (Domain_id is 2)
The singular call is done as so 
'''
http://localhost:8000/api/v1/domainreport?domain_id=2
'''
For easier hookup to front-end I designed the reports to be batched by domains meaning all the grades for a singular domain is given instead of one giant dictionary of all the grades. 
As always this is based on the current login of the user and will not work if the login is not mapped to an existing user. 
For the for the front-end people if you would like more data attached, let me know what you need to help you in whatever way to hook up this data 

For General Cleanup
New student info route created to just give the student information of the student. Works the same way /report so need to provide any parameters
'''
http://localhost:8000/api/v1/student/info
'''

No need to prune all grade data anytime you just need basic student info for displaying stuff. Which is what I think you were using for the settings page

Also moved all of the database report querying funcitons to database.py if anyone would need to use it for other features. Again all it needs is a studentid, a database as it's paremeters to give you a pydantic  object for easy usage. 

Alongside this added tests for the new Student/Info Route alongisde the Domain/Report Route also 