### PR TITLE
Faculty Routing Complete 

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
-from .endpoints import auth, risk, settings, student, report, settings
+from .endpoints import auth, risk, settings, student, report, settings, faculty
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(risk.router, prefix="/info", tags=["info"])
 api_router.include_router(student.router, prefix="/student", tags=["student"])
+api_router.include_router(faculty.router, prefix="/faculty", tags=["faculty"])
 api_router.include_router(report.router, prefix="", tags=["report"])
 api_router.include_router(settings.router, prefix="/settings", tags=["settings"])

--- a/backend/app/api/v1/endpoints/faculty.py
+++ b/backend/app/api/v1/endpoints/faculty.py
@@ -1,11 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from app.core.database import (get_db,
     link_logininfo, 
-    generateStudentInformationReport, 
-    generateGradeReport, 
-    generateExamReport,
-    generateDomainReport
+    update_faculty_access
 )
 from app.core.security import (
     get_current_active_user
@@ -30,7 +27,7 @@ async def update_login(
     db: Session = Depends(get_db)
 ):
     try:
-        student = db.query(Student.studentid).filter(Student.logininfoid == current_user.logininfoid)
+        student = db.query(Student.studentid).filter(Student.logininfoid == current_user.logininfoid).first()
         if student:
             raise HTTPException(
                 status_code=400,
@@ -45,3 +42,32 @@ async def update_login(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while processing your request"
         )
+        
+@router.post("/reportpermissions")
+async def update_permissions(
+    faculty_id: int,
+    current_user: User = Depends(get_current_active_user),
+    year: Optional[int] = None,
+    student_ids: Optional[List[int]] = Query(None, description="List of ID to be granted permission to access"),
+    db: Session = Depends(get_db)
+):
+    try:
+        if not current_user.issuperuser:
+            raise HTTPException(
+                status_code=400,
+                detail="Error, you must be an admin to change faculty permissions"
+            )
+        
+        if year:
+            update_faculty_access(faculty_id, db, year)
+            
+        if student_ids:
+            update_faculty_access(faculty_id, db, None, student_ids)
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )
+        

--- a/backend/app/api/v1/endpoints/faculty.py
+++ b/backend/app/api/v1/endpoints/faculty.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from app.core.database import (get_db,
+    link_logininfo, 
+    generateStudentInformationReport, 
+    generateGradeReport, 
+    generateExamReport,
+    generateDomainReport
+)
+from app.core.security import (
+    get_current_active_user
+)
+from app.models import LoginInfo as User
+from app.models import (
+    Faculty,
+    Student
+)
+from app.schemas.reportschema import StudentCompleteReport, DomainReport, DomainGrouping
+
+import pandas as pd
+from typing import Optional, List
+from datetime import datetime
+
+router = APIRouter()
+
+@router.post("/updatelogin")
+async def update_login(
+    faculty_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    try:
+        student = db.query(Student.studentid).filter(Student.logininfoid == current_user.logininfoid)
+        if student:
+            raise HTTPException(
+                status_code=400,
+                detail="You can't be an student, you must be a faculty."
+            )
+
+        link_logininfo(faculty_id, current_user.logininfoid, "faculty")
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )

--- a/backend/app/api/v1/endpoints/faculty.py
+++ b/backend/app/api/v1/endpoints/faculty.py
@@ -36,6 +36,9 @@ async def update_login(
 
         link_logininfo(faculty_id, current_user.logininfoid, "faculty")
     
+    except HTTPException:
+        raise
+    
     except Exception as e:
         print(f"Login error: {str(e)}")
         raise HTTPException(
@@ -58,14 +61,33 @@ async def update_permissions(
                 detail="Error, you must be an admin to change faculty permissions"
             )
         
+        if year is None and (student_ids is None or len(student_ids) == 0):
+            raise HTTPException(
+                status_code=400,
+                detail="Error: At least one parameter is required, [year or student ids]"
+            )
+        
         if year:
-            update_faculty_access(faculty_id, db, year)
+            result, message = update_faculty_access(faculty_id, db, year)
+            if not result:
+                raise HTTPException(
+                    status_code=400,
+                    detail=message
+                )
             
         if student_ids:
-            update_faculty_access(faculty_id, db, None, student_ids)
+            result, message = update_faculty_access(faculty_id, db, None, student_ids)
+            if not result:
+                raise HTTPException(
+                    status_code=400,
+                    detail=message
+                )
+                
+    except HTTPException:
+        raise
     
     except Exception as e:
-        print(f"Login error: {str(e)}")
+        print(f"Unexepected Error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while processing your request"

--- a/backend/app/api/v1/endpoints/report.py
+++ b/backend/app/api/v1/endpoints/report.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse, StreamingResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
+from sqlalchemy import or_
 from app.core.database import (get_db, 
     generateStudentInformationReport, 
     generateGradeReport, 
@@ -12,9 +13,13 @@ from app.core.security import (
 )
 from app.models import LoginInfo as User
 from app.models import (
-    Student
+    Student,
+    ClassRoster,
+    FacultyAccess,
+    Faculty,
+    GraduationStatus
 )
-from app.schemas.reportschema import StudentCompleteReport, DomainReport, DomainGrouping
+from app.schemas.reportschema import StudentCompleteReport, DomainReport, DomainGrouping, AccessibleStudentInfo
 
 import pandas as pd
 from typing import Optional, List
@@ -23,6 +28,25 @@ from datetime import datetime
 
 router = APIRouter()
 
+#Checks if a faculty member has access to a specific student (either by year or month)
+def check_faculty_access(faculty_id, student_id, db):
+
+    student_year = db.query(GraduationStatus.rosteryear).filter(
+        GraduationStatus.studentid == student_id
+    ).scalar()
+    
+    if student_year is None:
+        return False
+    
+    # Returns a true or false
+    return db.query(FacultyAccess).filter(
+        FacultyAccess.facultyid == faculty_id,
+        or_(
+            FacultyAccess.studentid == student_id,
+            FacultyAccess.rosteryear == student_year
+        )
+    ).first() is not None
+
 #Generates a student report based on a student's information, total exams, and grades
 @router.get("/report", response_model=StudentCompleteReport)
 async def generate_report(
@@ -30,7 +54,6 @@ async def generate_report(
     db: Session = Depends(get_db)
 ):
     try:
-        print(current_user.username)
         if current_user.issuperuser:
             raise HTTPException(
                 status_code=403,
@@ -109,6 +132,217 @@ async def generate_domain_report(
             
         return {"Domains": domain_reports}
     
+    except HTTPException:
+        raise
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )
+        
+@router.get("/faculty_report", response_model=StudentCompleteReport)
+async def generate_faculty_report(
+    student_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    try:
+        
+        is_student = db.query(Student.studentid).filter(
+            Student.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if is_student:
+            raise HTTPException(
+                status_code=403,
+                detail="Only faculty members can access this route"
+            )
+            
+        faculty = db.query(Faculty).filter(
+            Faculty.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if not faculty:
+            raise HTTPException(
+                status_code=404,
+                detail="No faculty Info Found"
+            )
+        
+        if not check_faculty_access(faculty.facultyid, student_id, db):
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to access this student's report"
+            )
+        
+        studentinfo = generateStudentInformationReport(student_id, db)
+        if not studentinfo:
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to acces this student's report"
+            )
+            
+        #Exams and Grades can be empty if they have no exams/grades on records
+        exams = generateExamReport(student_id, db) or []
+        
+        grades = generateGradeReport(student_id, db) or []
+        
+        
+        return StudentCompleteReport(
+            StudentInfo = studentinfo,
+            Exams = exams,
+            Grades = grades
+        )
+    
+    except HTTPException:
+        raise
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )
+        
+@router.get("/faculty_class_report", response_model=List[StudentCompleteReport])
+async def generate_faculty_class_report(
+    rosteryear: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    try:
+        
+        is_student = db.query(Student.studentid).filter(
+            Student.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if is_student:
+            raise HTTPException(
+                status_code=403,
+                detail="Only faculty members can access this route"
+            )
+            
+        faculty = db.query(Faculty).filter(
+            Faculty.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if not faculty:
+            raise HTTPException(
+                status_code=404,
+                detail="No faculty Info Found"
+            )
+        
+        year_access = db.query(FacultyAccess).filter_by(
+            facultyid=faculty.facultyid,
+            rosteryear=rosteryear
+        ).first
+        
+        if not year_access:
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to access this class year"
+            )
+        
+        
+        student_ids = db.query(Student.studentid).join(ClassRoster).filter(
+            ClassRoster.rosteryear == rosteryear
+        ).all()
+        
+        reports = []
+        
+        for (student_id,) in student_ids:
+            studentinfo = generateStudentInformationReport(student_id, db)
+            if not studentinfo:
+                continue
+            #Exams and Grades can be empty if they have no exams/grades on records
+            exams = generateExamReport(student_id, db) or []
+            grades = generateGradeReport(student_id, db) or []
+            
+            reports.append(StudentCompleteReport(
+                StudentInfo=studentinfo,
+                Exams=exams,
+                Grades=grades
+            ))
+            
+        return reports
+    
+    except HTTPException:
+        raise
+    
+    except Exception as e:
+        print(f"Login error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while processing your request"
+        )
+        
+@router.get("/faculty_access", response_model=List[AccessibleStudentInfo])
+async def get_accessible_students(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db) 
+):
+    try:
+        
+        is_student = db.query(Student.studentid).filter(
+            Student.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if is_student:
+            raise HTTPException(
+                status_code=403,
+                detail="Only faculty members can access this route"
+            )
+            
+        faculty = db.query(Faculty).filter(
+            Faculty.logininfoid == current_user.logininfoid
+        ).first()
+        
+        if not faculty:
+            raise HTTPException(
+                status_code=404,
+                detail="No faculty Info Found"
+            )
+        
+        student_access = db.query(
+            Student.studentid,
+            Student.firstname,
+            Student.lastname,
+            ClassRoster.rosteryear
+        ).join(
+            FacultyAccess, FacultyAccess.studentid == Student.studentid
+        ).join(
+            GraduationStatus, GraduationStatus.studentid == Student.studentid
+        ).filter(
+            FacultyAccess.facultyid == faculty.facultyid
+        )
+        
+        year_access = db.query(
+            Student.studentid,
+            Student.firstname,
+            Student.lastname,
+            ClassRoster.rosteryear
+        ).join(
+            GraduationStatus, GraduationStatus.studentid == Student.studentid
+        ).join(
+            FacultyAccess, FacultyAccess.rosteryear == GraduationStatus.rosteryear
+        ).filter(
+            FacultyAccess.facultyid == faculty.facultyid
+        ).filter(
+            FacultyAccess.facultyid == faculty.facultyid
+        )
+        
+        all_students = student_access.union(year_access).distinct.all()
+        
+        return [
+            AccessibleStudentInfo(
+                studentid=s.studentid,
+                name=f"{s.lastname}, {s.firstname}",
+                rosteryear=s.rosteryear
+            )
+            for s in all_students
+        ]
+        
     except HTTPException:
         raise
     

--- a/backend/app/api/v1/endpoints/student.py
+++ b/backend/app/api/v1/endpoints/student.py
@@ -80,9 +80,6 @@ async def generate_report(
         
         return studentinfo
     
-    except HTTPException:
-        raise
-    
     except Exception as e:
         print(f"Login error: {str(e)}")
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/student.py
+++ b/backend/app/api/v1/endpoints/student.py
@@ -44,6 +44,9 @@ async def update_login(
             )
 
         link_logininfo(student_id, current_user.logininfoid, "student")
+        
+    except HTTPException:
+        raise
     
     except Exception as e:
         print(f"Login error: {str(e)}")
@@ -79,6 +82,9 @@ async def generate_report(
             )
         
         return studentinfo
+    
+    except HTTPException:
+        raise
     
     except Exception as e:
         print(f"Login error: {str(e)}")

--- a/backend/app/api/v1/endpoints/student.py
+++ b/backend/app/api/v1/endpoints/student.py
@@ -43,7 +43,7 @@ async def update_login(
                 detail="You can't be an admin, you must be a student."
             )
 
-        link_logininfo(student_id, current_user.logininfoid)
+        link_logininfo(student_id, current_user.logininfoid, "student")
     
     except Exception as e:
         print(f"Login error: {str(e)}")

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -273,7 +273,7 @@ def update_faculty_access(id, db, year: Optional[int] = None, students_ids: Opti
         faculty = db.query(Faculty).filter(Faculty.facultyid == id).first()
         
         if faculty is None:
-            raise print("Error: No Faculty Member with this ID Found")
+            raise ValueError(f"Error: No Faculty Member with ID {id} Found")
         
         if year:
             db_access = FacultyAccess(
@@ -291,6 +291,11 @@ def update_faculty_access(id, db, year: Optional[int] = None, students_ids: Opti
                 db.add(db_access)
         
         db.commit()
+        return True, "Access Updated Successfully"
+    except ValueError as e:
+        db.rollback()
+        return False, str(e)
     except Exception as e:
-        print(f'Unexpected Error: {e}')
+        db.rollback()
+        return False, f"Database Error: {str(e)}"
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -14,7 +14,8 @@ from app.models import (
     StudentGrade,
     ClassOffering,
     Domain,
-    ClassDomain
+    ClassDomain,
+    Faculty
 )
 from app.schemas.reportschema import StudentReport, ExamReport, GradeReport, DomainReport
 
@@ -93,21 +94,32 @@ def nuclear_clean():
     
     print("Complete database wipe performed")
     
-def link_logininfo(studentid, logininfoid):
+def link_logininfo(id, logininfoid, usertype):
     db = next(get_db())
     
     #Removes old link
-    other_users = db.query(Student).filter(Student.logininfoid == logininfoid).all()
-    for user in other_users:
-        user.logininfoid = None
-        db.commit()
+    other_students = db.query(Student).filter(Student.logininfoid == logininfoid).all()
+    for students in other_students:
+        students.logininfoid = None
+        
+        
+    other_faculty = db.query(Student).filter(Student.logininfoid == logininfoid).all()
+    for faculty in other_faculty:
+        faculty.logininfoid = None
+
+    db.commit()
     
-    student = db.query(Student).filter(Student.studentid == studentid).first()
+    if usertype.lower() == "student":
+        user = db.query(Student).filter(Student.studentid == id).first()
+    elif usertype.lower() == "faculty":
+        user = db.query(Faculty).filter(Faculty.facultyid == id).first()
+    else:
+        raise ValueError("Invalid user type")
     
-    if student:
-        student.logininfoid = logininfoid
-        student.firstname = "LeBron"
-        student.lastname = "James"
+    if user:
+        user.logininfoid = logininfoid
+        user.firstname = "LeBron"
+        user.lastname = "James"
         db.commit()
         
     db.close()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,7 +2,8 @@ from .user_models import (
     LoginInfo,
     Student,
     Faculty,
-    EnrollmentRecord
+    EnrollmentRecord,
+    FacultyAccess
 )
 
 from .exam_models import (

--- a/backend/app/models/misc_models.py
+++ b/backend/app/models/misc_models.py
@@ -11,6 +11,7 @@ class ClassRoster(Base):
     currentenrollment = Column('currentenrollment', Integer)
     
     graduation = relationship('GraduationStatus', back_populates='roster')
+    facultyAccess = relationship('FacultyAccess', back_populates='roster')
 
 class Extracurricular(Base):
     __tablename__ = 'extracurriculars'

--- a/backend/app/models/user_models.py
+++ b/backend/app/models/user_models.py
@@ -37,6 +37,8 @@ class Student(Base):
     #Found in classfacultymodels
     enrollmentRecord = relationship('EnrollmentRecord', back_populates='student')
     studentGrades = relationship('StudentGrade', back_populates='student')
+    
+    facultyAccess = relationship('FacultyAccess', back_populates='student')
 
 class Faculty(Base):
     __tablename__ = 'faculty'
@@ -49,6 +51,19 @@ class Faculty(Base):
     
     loginInfo = relationship('LoginInfo', back_populates='faculty')
     offering = relationship('ClassOffering', back_populates='faculty')
+    facultyAccess = relationship('FacultyAccess', back_populates='faculty')
+    
+class FacultyAccess(Base):
+    __tablename__ = 'facultyaccess'
+    
+    facultyaccessid = Column('facultyaccessid', Integer, Identity(start=1, increment=1), primary_key=True)
+    facultyid = Column('facultyid', Integer, ForeignKey('faculty.facultyid'))
+    studentid = Column('studentid', Integer, ForeignKey('student.studentid'))
+    rosteryear = Column('rosteryear', Integer, ForeignKey('classroster.rosteryear'))
+    
+    faculty = relationship('Faculty', back_populates='facultyAccess')
+    student = relationship('Student', back_populates='facultyAccess') 
+    roster = relationship('ClassRoster', back_populates='facultyAccess')
 
 class EnrollmentRecord(Base):
     __tablename__ = 'enrollmentrecord'

--- a/backend/app/schemas/pydantic_base_models/user_schemas.py
+++ b/backend/app/schemas/pydantic_base_models/user_schemas.py
@@ -37,6 +37,15 @@ class Faculty(BaseModel):
     
     class Config:
         from_attributes = True
+        
+class FacultyAccess(BaseModel):
+    FacultyAccessID = int
+    FacultyID = Optional[int]
+    StudentID = Optional[int]
+    RosterYear = Optional[int]
+    
+    class Config:
+        from_attributes = True
     
 class EnrollmentRecord(BaseModel):
     EnrollmentRecord: int

--- a/backend/app/schemas/pydantic_base_models/user_schemas.py
+++ b/backend/app/schemas/pydantic_base_models/user_schemas.py
@@ -39,10 +39,10 @@ class Faculty(BaseModel):
         from_attributes = True
         
 class FacultyAccess(BaseModel):
-    FacultyAccessID = int
-    FacultyID = Optional[int]
-    StudentID = Optional[int]
-    RosterYear = Optional[int]
+    FacultyAccessID: Optional[int] = None
+    FacultyID:int
+    StudentID:Optional[int] = None
+    RosterYear: Optional[int] = None
     
     class Config:
         from_attributes = True

--- a/backend/app/schemas/reportschema.py
+++ b/backend/app/schemas/reportschema.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict
+import math
 
 #optional statements are present as dataset is incomplete or students are in progress
 class StudentReport(BaseModel):
@@ -17,6 +18,10 @@ class StudentReport(BaseModel):
     
     class Config:
         from_attributes = True
+        json_encoders = {
+        float: lambda x: None if math.isnan(x) else x
+    }
+        
     
 class ExamReport(BaseModel):
     ExamName: str
@@ -24,12 +29,22 @@ class ExamReport(BaseModel):
     PassScore: int
     PassOrFail: bool
     
+    class Config:
+        json_encoders = {
+        float: lambda x: None if math.isnan(x) else x
+    }
+    
 class GradeReport(BaseModel):
     ClassificationName: str
     PointsEarned: float
     PointsAvailable: float
     ClassID: int
     DateTaught: int
+    
+    class Config:
+        json_encoders = {
+        float: lambda x: None if math.isnan(x) else x
+    }
     
 class StudentCompleteReport(BaseModel):
     StudentInfo: StudentReport

--- a/backend/app/schemas/reportschema.py
+++ b/backend/app/schemas/reportschema.py
@@ -46,3 +46,11 @@ class DomainReport(BaseModel):
     
 class DomainGrouping(BaseModel):
     Domains: Dict[str, List[DomainReport]]
+    
+class AccessibleStudentInfo(BaseModel):
+    studentid: int
+    name: str
+    rosteryear: int
+    
+    class Config:
+        from_attributes = True

--- a/backend/app/tests/test_report.py
+++ b/backend/app/tests/test_report.py
@@ -2,9 +2,11 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from unittest.mock import patch, MagicMock
+from collections import namedtuple
 
 from app.main import app
 from app.models import LoginInfo as User
+from app.models import Student, Faculty, FacultyAccess, GraduationStatus
 from app.core.database import get_db
 from app.schemas.reportschema import StudentReport, ExamReport, GradeReport, DomainReport, StudentCompleteReport
 from app.core.security import (
@@ -130,6 +132,23 @@ def mock_domaindata():
         )
     ]
 
+@pytest.fixture
+def mock_faculty_user():
+    user = MagicMock(spec=User)
+    user.username = "Joe Worker"
+    user.logininfoid = 416
+    user.issuperuser = False
+    user.isactive = True
+    return user
+
+@pytest.fixture
+def test_faculty(mock_faculty_user, mock_db):
+    app.dependency_overrides[get_current_active_user] = lambda: mock_faculty_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides = {}
+
 class TestReport:
     
     def test_admin_access(self, test_admin):
@@ -252,6 +271,179 @@ class TestReport:
         assert domain_data[1]["ClassificationName"] == mock_domaindata[1].ClassificationName
         assert domain_data[1]["PointsEarned"] == mock_domaindata[1].PointsEarned
         
+    def test_faculty_report_isfaculty(self, test_faculty, mock_db, mock_studentdata, mock_examsdata, mock_gradesdata):
+
+        mock_student_query = MagicMock()
+        mock_student_query.filter.return_value.first.return_value = None
+
+        mock_faculty_query = MagicMock()
+        mock_faculty = MagicMock()
+        mock_faculty.facultyid = 1
+        mock_faculty_query.filter.return_value.first.return_value = mock_faculty
+
+        print("Mocked is_student result:", mock_student_query.filter.return_value.first.return_value)
+
+        # Mocking Query Behavior
+        def query_side_effect(model):
+            print(f"Intercepted query for model: {model}")
+            return {
+                Student: mock_student_query,
+                Student.studentid: mock_student_query,
+                Faculty: mock_faculty_query,
+                Faculty.logininfoid: mock_faculty_query
+            }.get(model, MagicMock())
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch("app.api.v1.endpoints.report.check_faculty_access", return_value=True), \
+            patch("app.api.v1.endpoints.report.generateStudentInformationReport", return_value=mock_studentdata), \
+            patch("app.api.v1.endpoints.report.generateExamReport", return_value=mock_examsdata), \
+            patch("app.api.v1.endpoints.report.generateGradeReport", return_value=mock_gradesdata):
+
+            response = test_faculty.get("/api/v1/faculty_report?student_id=12345")
+
+        print(f"Response Status: {response.status_code}")
+        print(f"Response Body: {response.text}")
+
+
+        assert response.status_code == 200
+        student_info = response.json()["StudentInfo"]
+        assert student_info["StudentID"] == mock_studentdata.StudentID
+        
+    def test_faculty_report_is_not_faculty(self, test_faculty, mock_db):
+
+        mock_student_query = MagicMock()
+        mock_student_query.filter.return_value.first.return_value = 1
+
+        mock_faculty_query = MagicMock()
+        mock_faculty = MagicMock()
+        mock_faculty.facultyid = None
+        mock_faculty_query.filter.return_value.first.return_value = mock_faculty
+
+        print("Mocked is_student result:", mock_student_query.filter.return_value.first.return_value)
+
+        # Assign query behavior
+        def query_side_effect(model):
+            print(f"Intercepted query for model: {model}")
+            return {
+                Student: mock_student_query,
+                Student.studentid: mock_student_query,
+                Faculty: mock_faculty_query,
+                Faculty.logininfoid: mock_faculty_query
+            }.get(model, MagicMock())
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch("app.api.v1.endpoints.report.check_faculty_access", return_value=True):
+            response = test_faculty.get("/api/v1/faculty_report?student_id=12345")
+
+        print(f"Response Status: {response.status_code}")
+        print(f"Response Body: {response.text}")
+
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Only faculty members can access this route"
+        
+    def test_faculty_report_no_student_access(self, test_faculty, mock_db):
+
+        mock_student_query = MagicMock()
+        mock_student_query.filter.return_value.first.return_value = None
+
+        mock_faculty_query = MagicMock()
+        mock_faculty = MagicMock()
+        mock_faculty.facultyid = 1
+        mock_faculty_query.filter.return_value.first.return_value = mock_faculty
+
+        # Mock routing for all query
+        def query_side_effect(model):
+            print(f"Intercepted query for model: {model}")
+            return {
+                Student: mock_student_query,
+                Student.studentid: mock_student_query,
+                Faculty: mock_faculty_query,
+                Faculty.logininfoid: mock_faculty_query
+            }.get(model, MagicMock())
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch("app.api.v1.endpoints.report.check_faculty_access", return_value=False):
+            response = test_faculty.get("/api/v1/faculty_report?student_id=12345")
+
+        print(f"Response Status: {response.status_code}")
+        print(f"Response Body: {response.text}")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "You do not have permission to access this student's report"
+        
+    def test_faculty_class_report_access_denied(self, test_faculty, mock_db):
+
+        mock_student_query = MagicMock()
+        mock_student_query.filter.return_value.first.return_value = None
+
+        mock_faculty_query = MagicMock()
+        mock_faculty = MagicMock()
+        mock_faculty.facultyid = 1
+        mock_faculty_query.filter.return_value.first.return_value = mock_faculty
+
+        mock_access_query = MagicMock()
+        mock_access_query.filter_by.return_value.first.return_value = None
+
+        # Mock Routing for all database Query
+        mock_db.query.side_effect = lambda model: {
+            Student: mock_student_query,
+            Student.studentid: mock_student_query,
+            Faculty: mock_faculty_query,
+            Faculty.logininfoid: mock_faculty_query,
+            FacultyAccess: mock_access_query,
+        }.get(model, MagicMock())
+
+        response = test_faculty.get("/api/v1/faculty_class_report?rosteryear=2022")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "You do not have permission to access this class year"
+        
+    def test_faculty_class_report_success(self, test_faculty, mock_db, mock_studentdata, mock_examsdata, mock_gradesdata):
+        
+        mock_student_query = MagicMock()
+        mock_student_query.filter.return_value.first.return_value = None
+    
+        mock_faculty_query = MagicMock()
+        mock_faculty = MagicMock()
+        mock_faculty.facultyid = 1
+        mock_faculty_query.filter.return_value.first.return_value = mock_faculty
+      
+        mock_access_query = MagicMock()
+        mock_access_query.filter_by.return_value.first.return_value = MagicMock()
+     
+        mock_student_ids_query = MagicMock()
+        mock_student_ids_query.join.return_value.filter.return_value.all.return_value = [(1,), (2,)]
+
+        # Mock Routing For All Database Queries
+        mock_db.query.side_effect = lambda model: {
+            Student: mock_student_query,
+            Student.studentid: mock_student_query,
+            Faculty: mock_faculty_query,
+            Faculty.logininfoid: mock_faculty_query,
+            FacultyAccess: mock_access_query,
+            GraduationStatus: mock_student_ids_query,
+        }.get(model, MagicMock())
+
+        with patch("app.api.v1.endpoints.report.generateStudentInformationReport", return_value=mock_studentdata), \
+            patch("app.api.v1.endpoints.report.generateExamReport", return_value=mock_examsdata), \
+            patch("app.api.v1.endpoints.report.generateGradeReport", return_value=mock_gradesdata):
+
+            response = test_faculty.get("/api/v1/faculty_class_report?rosteryear=2022")
+
+        assert response.status_code == 200
+
+        json_data = response.json()
+
+        for student_report in json_data:
+            assert student_report["StudentInfo"]["StudentID"] == mock_studentdata.StudentID
+            assert student_report["StudentInfo"]["LastName"] == mock_studentdata.LastName
+            assert student_report["Exams"][0]["ExamName"] == mock_examsdata[0].ExamName
+            assert student_report["Grades"][0]["PointsEarned"] == mock_gradesdata[0].PointsEarned
+            
 if __name__ == "__main__":
     pytest.main(["-v", __file__])
     


### PR DESCRIPTION
### Faculty Report Structure if Fully Complete

## Faculty Route
/faculty has been created and currently has two routes.

# /updatelogin
Self Explanatory works the same as student update login. 

# /reportpermissions 
Route to give permission to look at specific student reports and or entire class groups. Can only be called by a superuser and takes in years or a list of students to update specific routes. (Should be able to do both with one call)

## Report Route Update
Within the report route three new faculty specific routes have been created

# /faculty_report
Gives a faculty member a singular student's report if they currently have access to it (This includes direct studentid access or grouped access from a specific roster year)

# /faculty_class_report
Gives a faculty member an entire class report if they are given access to it

# /faculty_access
Gives a list of all students a faculty member has access to.  

# Unit Tests
Lastly all of the report functions have testing functionality and I think I caught most of the cases so they should work as expected.  